### PR TITLE
fix for unassigned variable 'locale' error

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -6,15 +6,16 @@ description=Plugin to easily load the available dutch PDOK (Publieke Dienstverle
 about=Nederlands:
 
         - Plugin om eenvoudiger PDOK services (WMS, WMTS, WFS en WCS) te laden in QGIS.
-        - Vind u dit een handige plugin? Stuur eens een (klein) Tikkie: https://tikkie.me/pay/l1adcj37rf5te3mn3fe2 Zie verder de 'homepage' van deze plugin.
+        - Vindt u dit een handige plugin? Stuur eens een (klein) Tikkie: https://tikkie.me/pay/l1adcj37rf5te3mn3fe2 Zie verder de 'homepage' van deze plugin.
         - Een paar opmerkingen: alle dataset en de url's zijn te vinden op https://data.pdok.nl
         - LET OP: van sommige (vooral grote) dataset worden/zijn de WFS services uitgefaseerd, en dan vervangen door een ATOM-feed. In de feed zit dan een download-url voor de gehele dataset. Die feed moet u zelf van https://data.pdok.nl ophalen.
 
-version=3.5.3
+version=3.5.4
 author=Richard Duivenvoorde
 email=richard@zuidt.nl
 
 changelog=
+    3.5.4   (??-????) Remove all (i18n) translation code
     3.5.3   (01-2021) Fix Qt-scene warning, Fix Windows Locale issue, Fix WCS ahn service, Update PDOK services. Test with Tikkie and Betaalverzoek
     3.5.2   (08-2020) Fix urlencoding issue, Remove some old NON-working services
     3.5.1   (07-2020) Remove redundant (not working) BAG url's (thanks Gerben D)

--- a/pdokservicesplugin.py
+++ b/pdokservicesplugin.py
@@ -81,13 +81,14 @@ class PdokServicesPlugin(object):
         # initialize locale
         localePath = ""
         if isinstance(QSettings().value("locale/userLocale"), QVariant):
-            if not QSettings().value("locale/userLocale").isNull():
-                locale = QSettings().value("locale/userLocale").value()[0:2]
+            locale = QSettings().value("locale/userLocale", 'en')
+            if len(locale) > 2:
+                locale = locale[:2]
         else:
-            locale = QSettings().value("locale/userLocale")[0:2]
+            locale = 'en'
 
         if QFileInfo(self.plugin_dir).exists():
-            localePath = self.plugin_dir + "/i18n/pdokservicesplugin_" + locale + ".qm"
+            localePath = os.path.join(self.plugin_dir, 'i18n', f'pdokservicesplugin_{locale}.qm')
 
         if QFileInfo(localePath).exists():
             self.translator = QTranslator()

--- a/pdokservicesplugin.py
+++ b/pdokservicesplugin.py
@@ -78,23 +78,6 @@ class PdokServicesPlugin(object):
         self.dlg = PdokServicesPluginDialog(parent=self.iface.mainWindow())
         # initialize plugin directory
         self.plugin_dir = QFileInfo(QgsApplication.qgisUserDatabaseFilePath()).path() + "/python/plugins/pdokservicesplugin"
-        # initialize locale
-        localePath = ""
-        if isinstance(QSettings().value("locale/userLocale"), QVariant):
-            locale = QSettings().value("locale/userLocale", 'en')
-            if len(locale) > 2:
-                locale = locale[:2]
-        else:
-            locale = 'en'
-
-        if QFileInfo(self.plugin_dir).exists():
-            localePath = os.path.join(self.plugin_dir, 'i18n', f'pdokservicesplugin_{locale}.qm')
-
-        if QFileInfo(localePath).exists():
-            self.translator = QTranslator()
-            self.translator.load(localePath)
-            if qVersion() > '4.3.3':
-                QCoreApplication.installTranslator(self.translator)
         self.currentLayer = None
         self.SETTINGS_SECTION = '/pdokservicesplugin/'
         self.pointer = None


### PR DESCRIPTION
Fixes this:
https://geoforum.nl/t/pdok-services-plug-in-installatie-error-vanuit-qgis-versie-3-10-12-1/5317

(BTW, removing all i18n code would make sense as the plugin strings are coded in Dutch so nothing could be translated anyway...)