### PR TITLE
ahn process alg:move WCS capabilities and describecoverage calls to processAlgorithm function

### DIFF
--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -1287,7 +1287,9 @@ class PdokServicesPlugin(object):
                     title = fav_layer["title"].capitalize()
                     if "selectedStyle" in fav_layer:
                         style = fav_layer["selectedStyle"]
-                        style_title = style["name"]
+
+                        if "name" in style:
+                            style_title = style["name"]
                         if "title" in style:
                             style_title = style["title"]
                         if style_title:


### PR DESCRIPTION
ahn process alg: move WCS capabilities and describecoverage calls to processAlgorithm function (so no more failed http calls on startup). 

Het was me niet gelukt om op het moment van tonen van het process-algorithm de WCS te bevragen. Ik kon er niets over vinden in de documentatie of op het web. 