### PR TITLE
Support adding and retrieving OGC:API tiles/features services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ pdokservicesplugin/resources/infotab.html.escaped
 symbology-style.db
 user-history.db
 venv/
+.venv/
 spider/*.json

--- a/README.md
+++ b/README.md
@@ -94,3 +94,5 @@ symlink_path "$(realpath ~)/.local/share/QGIS/QGIS3/profiles/pdokplugin-develop/
 mkdir -p $(dirname "$symlink_path")
 ln -s "$(pwd)/pdokservicesplugin" "$symlink_path" # uitvoeren vanuit root van repo
 ```
+
+# TODO: document modify-layers-pdok-ogcapi.py

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 This plugin is probably only interesting for the dutch audience.
 
 It shows a list of available web services (WMS, WMTS, WFS, OGC:API tiles/features etc) from our
-national data services (in our national crs epsg:28992).
+national data services (in our national crs EPSG:28992).
 Further information in dutch below.
 
-If you think this plugin is usefull, consider to donate via Paypal button below, OR sent me a kind email of tweet :-)
+If you think this plugin is useful, consider to donate via Paypal button below, OR sent me a kind email of tweet :-)
 
 ## Nederlands
 
-PDOK (Publieke Data Op de Kaart) is een plugin om de verschillende
+PDOK (Publieke Dienstverlening Op de Kaart) is een plugin om de verschillende
 PDOK services te testen of te bekijken.
 
 Op basis van een json bestand (IN de plugin) met alle op dit moment beschikbare services wordt een dialoog opgebouwd met daarin
@@ -21,9 +21,9 @@ Op basis van een json bestand (IN de plugin) met alle op dit moment beschikbare 
 - de naam van de service
 - een regel per laag van de service
 
-Door op een item te klikken wordt de service direkt aangeroepen een getoond.
+Door op een item te klikken wordt de service direct aangeroepen een getoond.
 
-Alle services zijn epsg:28992
+Alle services zijn minstens in EPSG:28992 beschikbaar
 
 [![paypal](https://www.paypalobjects.com/en_US/NL/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=DZ8R5JPAW55CJ&currency_code=EUR&source=url)
 

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ mkdir -p $(dirname "$symlink_path")
 ln -s "$(pwd)/pdokservicesplugin" "$symlink_path" # uitvoeren vanuit root van repo
 ```
 
-# TODO: document modify-layers-pdok-ogcapi.py
+Extend the layers config file using OGC:API urls, see [`scripts/modify-layers-pdok-ogcapi.py`](scripts/modify-layers-pdok-ogcapi.py) for more detailed instructions.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This plugin is probably only interesting for the dutch audience.
 
-It shows a list of available web services (WMS, WMTS, WFS etc) from our
+It shows a list of available web services (WMS, WMTS, WFS, OGC:API tiles/features etc) from our
 national data services (in our national crs epsg:28992).
 Further information in dutch below.
 
@@ -17,7 +17,7 @@ PDOK services te testen of te bekijken.
 
 Op basis van een json bestand (IN de plugin) met alle op dit moment beschikbare services wordt een dialoog opgebouwd met daarin
 
-- het soort service (WMS, WMTS, WFS of TMS)
+- het soort service (WMS, WMTS, WFS, TMS, OGC:API tiles/features)
 - de naam van de service
 - een regel per laag van de service
 

--- a/pdokservicesplugin/metadata.txt
+++ b/pdokservicesplugin/metadata.txt
@@ -10,7 +10,7 @@ about=Nederlands:
         - Een paar opmerkingen: alle dataset en de url's zijn te vinden op https://www.pdok.nl/datasets
         - LET OP: van sommige (vooral grote) dataset worden/zijn de WFS services uitgefaseerd, en dan vervangen door een ATOM-feed. In de feed zit dan een download-url voor de gehele dataset. Die feed moet u zelf van https://www.pdok.nl/datasets ophalen.
 
-version=4.1.6
+version=4.2.0
 
 author=Richard Duivenvoorde
 email=richard@zuidt.nl

--- a/pdokservicesplugin/metadata.txt
+++ b/pdokservicesplugin/metadata.txt
@@ -5,7 +5,7 @@ qgisMaximumVersion=3.99
 description=Plugin to easily load the available Dutch PDOK (Publieke Dienstverlening Op de Kaart) services. Currently only in Dutch.
 about=Nederlands:
 
-        - Plugin om eenvoudiger PDOK services (WMS, WMTS, WFS, WCS en OGC:API tiles) te laden in QGIS.
+        - Plugin om eenvoudiger PDOK services (WMS, WMTS, WFS, WCS en OGC:API tiles/features) te laden in QGIS.
         - Vindt u dit een handige plugin? Stuur eens een (klein) Tikkie of een ASN betaling. Zie verder de 'homepage' van deze plugin: https://github.com/rduivenvoorde/pdokservicesplugin
         - Een paar opmerkingen: alle dataset en de url's zijn te vinden op https://www.pdok.nl/datasets
         - LET OP: van sommige (vooral grote) dataset worden/zijn de WFS services uitgefaseerd, en dan vervangen door een ATOM-feed. In de feed zit dan een download-url voor de gehele dataset. Die feed moet u zelf van https://www.pdok.nl/datasets ophalen.

--- a/pdokservicesplugin/metadata.txt
+++ b/pdokservicesplugin/metadata.txt
@@ -1,14 +1,14 @@
 [general]
 name=PDOK services plugin
-qgisMinimumVersion=3.10
+qgisMinimumVersion=3.14
 qgisMaximumVersion=3.99
 description=Plugin to easily load the available Dutch PDOK (Publieke Dienstverlening Op de Kaart) services. Currently only in Dutch.
 about=Nederlands:
 
-        - Plugin om eenvoudiger PDOK services (WMS, WMTS, WFS en WCS) te laden in QGIS.
+        - Plugin om eenvoudiger PDOK services (WMS, WMTS, WFS, WCS en OGC:API tiles) te laden in QGIS.
         - Vindt u dit een handige plugin? Stuur eens een (klein) Tikkie of een ASN betaling. Zie verder de 'homepage' van deze plugin: https://github.com/rduivenvoorde/pdokservicesplugin
-        - Een paar opmerkingen: alle dataset en de url's zijn te vinden op https://data.pdok.nl
-        - LET OP: van sommige (vooral grote) dataset worden/zijn de WFS services uitgefaseerd, en dan vervangen door een ATOM-feed. In de feed zit dan een download-url voor de gehele dataset. Die feed moet u zelf van https://data.pdok.nl ophalen.
+        - Een paar opmerkingen: alle dataset en de url's zijn te vinden op https://www.pdok.nl/datasets
+        - LET OP: van sommige (vooral grote) dataset worden/zijn de WFS services uitgefaseerd, en dan vervangen door een ATOM-feed. In de feed zit dan een download-url voor de gehele dataset. Die feed moet u zelf van https://www.pdok.nl/datasets ophalen.
 
 version=4.1.6
 
@@ -16,6 +16,7 @@ author=Richard Duivenvoorde
 email=richard@zuidt.nl
 
 changelog=
+    4.2.0   (12-2023) support ogcapi tiles and update services
     4.1.6   (12-2023) update service url's, fix #99 (ability to remove old favs), save fq filter state to QSettings, make it possible (and create setting) to use the old yellow cross again (no flashing geom), fix LS filter
     4.1.5   (06-2023) quickfix for ahn4 wcs (Anton)
     4.1.4   (06-2023) update service url's fix ahn processing algo (NOT requesting caps on startup) (Both: Thanks Anton!)

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -955,7 +955,8 @@ class PdokServicesPlugin(object):
             # We add OAF layers to layers_pdok list 
             urls_oaf = [
                 "https://demo.ldproxy.net/daraa", 
-                "https://test.haleconnect.de/ogcapi/datasets/hydro-example"
+                "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
+                "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses"
             ]
             self.layers_pdok = self.retrieve_layers_from_oaf_endpoint(urls = urls_oaf)
             pdokjson = os.path.join(self.plugin_dir, "resources", "layers-pdok.json")

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -359,10 +359,24 @@ class PdokServicesPlugin(object):
             "WFS": "Featuretype",
         }
         layername_key = f"{layername_key_mapping[stype]}"
-        dataset_metadata_dd = self.get_dd(
-            dataset_md_id,
-            f'<a title="Bekijk dataset metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{dataset_md_id}">{dataset_md_id}</a>',
-        )
+        if stype == 'OAPIF': # OAPIF Daraa dataset is not in NGR
+            dataset_metadata_dd = self.get_dd(
+                'oapif',
+                f'<a title="Bekijk dataset metadata van OAPIF" href="{url}/collections/{layername}">{title}/{layername}</a>',
+            )
+            service_metadata_dd = self.get_dd(
+                'oapif',
+                f'<a title="Bekijk service metadata van OAPIF" href="{url}">{service_title}</a>',
+            )
+        else:
+            dataset_metadata_dd = self.get_dd(
+                dataset_md_id,
+                f'<a title="Bekijk dataset metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{dataset_md_id}">{dataset_md_id}</a>',
+            )
+            service_metadata_dd = self.get_dd(
+                service_md_id,
+                f'<a title="Bekijk service metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{service_md_id}">{service_md_id}</a>',
+            )
         fav_string = ""
         fav_title = ""
         if fav:

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -641,7 +641,10 @@ class PdokServicesPlugin(object):
             type = "xyz"
             uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
             tileLayer = QgsVectorTileLayer(uri, title)
+
+            # Set the VT layer CRS and load the styleUrl
             tileLayer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+            tileLayer.loadDefaultStyle()
             return tileLayer
         else:
             self.show_warning(

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -378,25 +378,14 @@ class PdokServicesPlugin(object):
             "OGC API - Tiles": "Vector Tiles",
         }
         layername_key = f"{layername_key_mapping[stype]}"
-        # Go to endpoint of ogcapi features since no features in ngr
-        if stype == "OGC API - Features":
-            dataset_metadata_dd = self.get_dd(
-                stype,
-                f'<a title="Bekijk dataset metadata van OAPIF" href="{url}/collections/{layername}">{title} - {layername}</a>',
-            )
-            service_metadata_dd = self.get_dd(
-                stype,
-                f'<a title="Bekijk service metadata van OAPIF" href="{url}">{service_title}</a>',
-            )
-        else:
-            dataset_metadata_dd = self.get_dd(
-                dataset_md_id,
-                f'<a title="Bekijk dataset metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{dataset_md_id}">{dataset_md_id}</a>',
-            )
-            service_metadata_dd = self.get_dd(
-                service_md_id,
-                f'<a title="Bekijk service metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{service_md_id}">{service_md_id}</a>',
-            )
+        dataset_metadata_dd = self.get_dd(
+            dataset_md_id,
+            f'<a title="Bekijk dataset metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{dataset_md_id}">{dataset_md_id}</a>',
+        )
+        service_metadata_dd = self.get_dd(
+            service_md_id,
+            f'<a title="Bekijk service metadata in NGR" href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/{service_md_id}">{service_md_id}</a>',
+        )
         fav_string = ""
         fav_title = ""
         if fav:

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -636,12 +636,7 @@ class PdokServicesPlugin(object):
                 + used_tileset["tileset_id"]
                 + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
             )
-            if crs == "EPSG:28992":
-                maxz_coord = 12
-            elif crs == "EPSG:4258" or crs == "EPSG:3035":
-                maxz_coord = 14
-            else:
-                maxz_coord = 17
+            maxz_coord = used_tileset["tileset_max_zoomlevel"]
             minz_coord = 1
             # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -516,7 +516,7 @@ class PdokServicesPlugin(object):
                 (
                     x
                     for x in self.current_layer["styles"]
-                    if x["title"] == selected_style_title
+                    if 'title' in x and x["title"] == selected_style_title 
                 ),
                 None,
             )

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -655,8 +655,8 @@ class PdokServicesPlugin(object):
         maxz_coord = used_tileset["tileset_max_zoomlevel"]
 
         # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
-        # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
-        minz_coord = 1
+        # we need to set the minimum z value to 0, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
+        minz_coord = 0
 
         type = "xyz"
         uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -334,7 +334,11 @@ class PdokServicesPlugin(object):
         )
         layername = self.current_layer["name"]
         service_abstract_dd = self.get_dd(self.current_layer["service_abstract"])
-        stype = self.service_type_mapping[self.current_layer["service_type"]] if self.current_layer["service_type"] in self.service_type_mapping else self.current_layer["service_type"].upper()
+        stype = (
+            self.service_type_mapping[self.current_layer["service_type"]]
+            if self.current_layer["service_type"] in self.service_type_mapping
+            else self.current_layer["service_type"].upper()
+        )
         minscale = ""
         if "minscale" in self.current_layer:
             minscale = self.format_scale_denominator(self.current_layer["minscale"])
@@ -486,15 +490,14 @@ class PdokServicesPlugin(object):
                 if crs[i] == "EPSG:28992":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
-
-    def extract_crs(self,crs_string):
-        pattern = r'/EPSG/(\d+)/(\d+)'
+    def extract_crs(self, crs_string):
+        pattern = r"/EPSG/(\d+)/(\d+)"
         match = re.search(pattern, crs_string)
         if match:
             return f"EPSG:{match.group(2)}"
         else:
             return crs_string
-        
+
     def quote_wmts_url(self, url):
         """
         Quoten wmts url is nodig omdat qgis de query param `SERVICE=WMS` erachter plakt als je de wmts url niet quote.
@@ -516,7 +519,7 @@ class PdokServicesPlugin(object):
                 (
                     x
                     for x in self.current_layer["styles"]
-                    if 'title' in x and x["title"] == selected_style_title 
+                    if "title" in x and x["title"] == selected_style_title
                 ),
                 None,
             )
@@ -605,7 +608,7 @@ class PdokServicesPlugin(object):
             return QgsRasterLayer(uri, title, "wcs")
         elif servicetype == "api features":  # OGC API Features
             uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
-            return QgsVectorLayer(uri, title, 'OAPIF')
+            return QgsVectorLayer(uri, title, "OAPIF")
         elif servicetype == "api tiles":  # OGC API Tiles
 
             # CRS met oat werkt nog niet correct in qgis/gdal
@@ -614,7 +617,7 @@ class PdokServicesPlugin(object):
                 "EPSG:28992": "NetherlandsRDNewQuad",
                 "EPSG:3857": "WebMercatorQuad",
                 "EPSG:4258": "EuropeanETRS89_GRS80Quad_Draft",
-                "EPSG:3035": "EuropeanETRS89_LAEAQuad"
+                "EPSG:3035": "EuropeanETRS89_LAEAQuad",
             }
             # Style toevoegen in laag vanuit ui
             selected_style_name = (
@@ -635,7 +638,7 @@ class PdokServicesPlugin(object):
                 maxz_coord = 14
             else:
                 maxz_coord = 17
-            minz_coord = 1 # Better performance wise, see QGIS issue https://github.com/qgis/QGIS/issues/54312
+            minz_coord = 1  # Better performance wise, see QGIS issue https://github.com/qgis/QGIS/issues/54312
             type = "xyz"
             uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
             return QgsVectorTileLayer(uri, title)
@@ -799,17 +802,18 @@ class PdokServicesPlugin(object):
     def add_source_row(self, serviceLayer):
         # you can attache different "data's" to to an QStandarditem
         # default one is the visible one:
-        stype = self.service_type_mapping[serviceLayer["service_type"]] if serviceLayer["service_type"] in self.service_type_mapping else serviceLayer["service_type"].upper()
+        stype = (
+            self.service_type_mapping[serviceLayer["service_type"]]
+            if serviceLayer["service_type"] in self.service_type_mapping
+            else serviceLayer["service_type"].upper()
+        )
         itemType = QStandardItem(str(stype))
         # userrole is a free form one:
         # only attach the data to the first item
         # service layer = a dict/object with all props of the layer
 
-
         itemType.setData(serviceLayer, Qt.UserRole)
-        itemType.setToolTip(
-            f'{stype} - {serviceLayer["title"]}'
-        )
+        itemType.setToolTip(f'{stype} - {serviceLayer["title"]}')
         # only wms services have styles (sometimes)
         layername = serviceLayer["title"]
         styles_string = ""
@@ -819,17 +823,13 @@ class PdokServicesPlugin(object):
             )
 
         itemLayername = QStandardItem(str(serviceLayer["title"]))
-        itemLayername.setToolTip(
-            f'{stype} - {serviceLayer["service_title"]}'
-        )
+        itemLayername.setToolTip(f'{stype} - {serviceLayer["service_title"]}')
         # itemFilter is the item used to search filter in. That is why layername is a combi of layername + filter here
         itemFilter = QStandardItem(
             f'{serviceLayer["service_type"]} {layername} {serviceLayer["service_title"]} {serviceLayer["service_abstract"]} {styles_string}'
         )
         itemServicetitle = QStandardItem(str(serviceLayer["service_title"]))
-        itemServicetitle.setToolTip(
-            f'{stype} - {serviceLayer["title"]}'
-        )
+        itemServicetitle.setToolTip(f'{stype} - {serviceLayer["title"]}')
         self.sourceModel.appendRow(
             [itemLayername, itemType, itemServicetitle, itemFilter]
         )

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -180,8 +180,8 @@ class PdokServicesPlugin(object):
             "wmts": "WMTS",
             "wfs": "WFS",
             "wcs": "WCS",
-            "api features": "OGC API - features",
-            "api tiles": "OGC API - tiles",
+            "api features": "OGC API - Features",
+            "api tiles": "OGC API - Tiles",
         }
 
         self.add_fav_actions_to_toolbar_button()
@@ -374,12 +374,12 @@ class PdokServicesPlugin(object):
             "WMS": "Layer",
             "WMTS": "Layer",
             "WFS": "Featuretype",
-            "OGC API - features": "OGC API - features",
-            "OGC API - tiles": "Vector tiles",
+            "OGC API - Features": "OGC API - Features",
+            "OGC API - Tiles": "Vector Tiles",
         }
         layername_key = f"{layername_key_mapping[stype]}"
         # Go to endpoint of ogcapi features since no features in ngr
-        if stype == "OGC API - features":
+        if stype == "OGC API - Features":
             dataset_metadata_dd = self.get_dd(
                 stype,
                 f'<a title="Bekijk dataset metadata van OAPIF" href="{url}/collections/{layername}">{title} - {layername}</a>',
@@ -432,17 +432,17 @@ class PdokServicesPlugin(object):
         self.dlg.ui.wmsStyleComboBox.clear()
 
         show_list = {
-            self.dlg.ui.comboSelectProj: ["WMS", "WMTS", "OGC API - tiles"],
-            self.dlg.ui.labelCrs: ["WMS", "WMTS", "OGC API - tiles"],
-            self.dlg.ui.wmsStyleComboBox: ["WMS", "OGC API - tiles"],
-            self.dlg.ui.wmsStyleLabel: ["WMS", "OGC API - tiles"],
+            self.dlg.ui.comboSelectProj: ["WMS", "WMTS", "OGC API - Tiles"],
+            self.dlg.ui.labelCrs: ["WMS", "WMTS", "OGC API - Tiles"],
+            self.dlg.ui.wmsStyleComboBox: ["WMS", "OGC API - Tiles"],
+            self.dlg.ui.wmsStyleLabel: ["WMS", "OGC API - Tiles"],
         }
 
         for ui_el in show_list.keys():
             service_types = show_list[ui_el]
             ui_el.setHidden(not (stype in service_types))
 
-        if stype == "WMS" or stype == "OGC API - tiles":
+        if stype == "WMS" or stype == "OGC API - Tiles":
             styles = self.current_layer["styles"]
             nr_styles = len(styles)
             style_str = "styles" if nr_styles > 1 else "style"
@@ -472,14 +472,14 @@ class PdokServicesPlugin(object):
                 if crs[i] == "EPSG:28992":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
-        if stype == "WMTS":
+        elif stype == "WMTS":
             tilematrixsets = self.current_layer["tilematrixsets"].split(",")
             self.dlg.ui.comboSelectProj.addItems(tilematrixsets)
             for i in range(len(tilematrixsets)):
                 if tilematrixsets[i].startswith("EPSG:28992"):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
-        if stype == "OGC API - tiles":
+        elif stype == "OGC API - Tiles":
             try:
                 crs = self.current_layer["crs"]
             except KeyError:
@@ -538,10 +538,8 @@ class PdokServicesPlugin(object):
 
     def get_crs_comboselect(self):
         if self.dlg.ui.comboSelectProj.currentIndex() == -1:
-            crs = "EPSG:28992"
-        else:
-            crs = self.dlg.ui.comboSelectProj.currentText()
-        return crs
+            return "EPSG:28992"
+        return self.dlg.ui.comboSelectProj.currentText()
 
     def create_new_layer(self):
         servicetype = self.current_layer["service_type"]

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -639,13 +639,13 @@ class PdokServicesPlugin(object):
             # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
             type = "xyz"
-            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
-            tileLayer = QgsVectorTileLayer(uri, title)
+            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&crs={crs}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
+            tile_layer = QgsVectorTileLayer(uri, title)
 
             # Set the VT layer CRS and load the styleUrl
-            tileLayer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
-            tileLayer.loadDefaultStyle()
-            return tileLayer
+            tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+            tile_layer.loadDefaultStyle()
+            return tile_layer
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -170,8 +170,18 @@ class PdokServicesPlugin(object):
             "wmts": "bottom",
             "wfs": "top",
             "wcs": "top",
-            "oapif": "top",
-            "oat": "bottom",
+            "api features": "top",
+            "api tiles": "bottom",
+        }
+
+        # Set default layer loading behaviour
+        self.service_type_mapping = {
+            "wms": "WMS",
+            "wmts": "WMTS",
+            "wfs": "WFS",
+            "wcs": "WCS",
+            "api features": "OGC API - features",
+            "api tiles": "OGC API - tiles",
         }
 
         self.add_fav_actions_to_toolbar_button()
@@ -324,7 +334,7 @@ class PdokServicesPlugin(object):
         )
         layername = self.current_layer["name"]
         service_abstract_dd = self.get_dd(self.current_layer["service_abstract"])
-        stype = self.current_layer["service_type"].upper()
+        stype = self.service_type_mapping(self.current_layer["service_type"]) if self.current_layer["service_type"] in self.service_type_mapping else self.current_layer["service_type"].upper()
         minscale = ""
         if "minscale" in self.current_layer:
             minscale = self.format_scale_denominator(self.current_layer["minscale"])
@@ -360,18 +370,18 @@ class PdokServicesPlugin(object):
             "WMS": "Layer",
             "WMTS": "Layer",
             "WFS": "Featuretype",
-            "OAPIF": "OGC API - Features",
-            "OAT": "OGC API - Tiles",
+            "OGC API - features": "OGC API - features",
+            "OGC API - tiles": "OGC API - tiles",
         }
         layername_key = f"{layername_key_mapping[stype]}"
-        # OAPIF Daraa dataset is not in NGR: ref to metadata page
-        if stype == "OAPIF":
+        # Go to endpoint of ogcapi features since no features in ngr
+        if stype == "OGC API - features":
             dataset_metadata_dd = self.get_dd(
-                "oapif",
+                stype,
                 f'<a title="Bekijk dataset metadata van OAPIF" href="{url}/collections/{layername}">{title} - {layername}</a>',
             )
             service_metadata_dd = self.get_dd(
-                "oapif",
+                stype,
                 f'<a title="Bekijk service metadata van OAPIF" href="{url}">{service_title}</a>',
             )
         else:
@@ -418,10 +428,10 @@ class PdokServicesPlugin(object):
         self.dlg.ui.wmsStyleComboBox.clear()
 
         show_list = {
-            self.dlg.ui.comboSelectProj: ["WMS", "WMTS", "OAT"],
-            self.dlg.ui.labelCrs: ["WMS", "WMTS", "OAT"],
-            self.dlg.ui.wmsStyleComboBox: ["WMS", "OAT"],
-            self.dlg.ui.wmsStyleLabel: ["WMS", "OAT"],
+            self.dlg.ui.comboSelectProj: ["WMS", "WMTS", "OGC API - tiles"],
+            self.dlg.ui.labelCrs: ["WMS", "WMTS", "OGC API - tiles"],
+            self.dlg.ui.wmsStyleComboBox: ["WMS", "OGC API - tiles"],
+            self.dlg.ui.wmsStyleLabel: ["WMS", "OGC API - tiles"],
         }
 
         for ui_el in show_list.keys():
@@ -458,12 +468,24 @@ class PdokServicesPlugin(object):
                 if crs[i] == "EPSG:28992":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
-        if stype == "WMTS" or stype == "OAT":
+        if stype == "WMTS":
             tilematrixsets = self.current_layer["tilematrixsets"].split(",")
             self.dlg.ui.comboSelectProj.addItems(tilematrixsets)
             for i in range(len(tilematrixsets)):
                 if tilematrixsets[i].startswith("EPSG:28992"):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
+
+        if stype == "OGC API - tiles":
+            try:
+                crs = self.current_layer["crs"]
+            except KeyError:
+                crs = "EPSG:28992"
+            crs = crs.split(",")
+            self.dlg.ui.comboSelectProj.addItems(crs)
+            for i in range(len(crs)):
+                if crs[i] == "EPSG:28992":
+                    self.dlg.ui.comboSelectProj.setCurrentIndex(i)
+
 
     def quote_wmts_url(self, url):
         """

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -608,7 +608,7 @@ class PdokServicesPlugin(object):
             return QgsVectorLayer(uri, title, "OAPIF")
         elif servicetype == "api tiles":  # OGC API Tiles
 
-            # CRS met oat werkt nog niet correct in qgis/gdal
+            # CRS does not work correctly in qgis/gdal. We can set a crs (non-webmercator), but it is not displayed as expected.
             crs = self.get_crs_comboselect()
             crs_mapping = {
                 "EPSG:28992": "NetherlandsRDNewQuad",
@@ -640,7 +640,9 @@ class PdokServicesPlugin(object):
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
             type = "xyz"
             uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
-            return QgsVectorTileLayer(uri, title)
+            tileLayer = QgsVectorTileLayer(uri, title)
+            tileLayer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+            return tileLayer
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -334,7 +334,7 @@ class PdokServicesPlugin(object):
         )
         layername = self.current_layer["name"]
         service_abstract_dd = self.get_dd(self.current_layer["service_abstract"])
-        stype = self.service_type_mapping(self.current_layer["service_type"]) if self.current_layer["service_type"] in self.service_type_mapping else self.current_layer["service_type"].upper()
+        stype = self.service_type_mapping[self.current_layer["service_type"]] if self.current_layer["service_type"] in self.service_type_mapping else self.current_layer["service_type"].upper()
         minscale = ""
         if "minscale" in self.current_layer:
             minscale = self.format_scale_denominator(self.current_layer["minscale"])
@@ -371,7 +371,7 @@ class PdokServicesPlugin(object):
             "WMTS": "Layer",
             "WFS": "Featuretype",
             "OGC API - features": "OGC API - features",
-            "OGC API - tiles": "OGC API - tiles",
+            "OGC API - tiles": "Vector tiles",
         }
         layername_key = f"{layername_key_mapping[stype]}"
         # Go to endpoint of ogcapi features since no features in ngr
@@ -438,7 +438,7 @@ class PdokServicesPlugin(object):
             service_types = show_list[ui_el]
             ui_el.setHidden(not (stype in service_types))
 
-        if stype == "WMS" or stype == "OAT":
+        if stype == "WMS" or stype == "OGC API - tiles":
             styles = self.current_layer["styles"]
             nr_styles = len(styles)
             style_str = "styles" if nr_styles > 1 else "style"
@@ -799,13 +799,16 @@ class PdokServicesPlugin(object):
     def add_source_row(self, serviceLayer):
         # you can attache different "data's" to to an QStandarditem
         # default one is the visible one:
-        itemType = QStandardItem(str(serviceLayer["service_type"].upper()))
+        stype = self.service_type_mapping[serviceLayer["service_type"]] if serviceLayer["service_type"] in self.service_type_mapping else serviceLayer["service_type"].upper()
+        itemType = QStandardItem(str(stype))
         # userrole is a free form one:
         # only attach the data to the first item
         # service layer = a dict/object with all props of the layer
+
+
         itemType.setData(serviceLayer, Qt.UserRole)
         itemType.setToolTip(
-            f'{serviceLayer["service_type"].upper()} - {serviceLayer["title"]}'
+            f'{stype} - {serviceLayer["title"]}'
         )
         # only wms services have styles (sometimes)
         layername = serviceLayer["title"]
@@ -817,7 +820,7 @@ class PdokServicesPlugin(object):
 
         itemLayername = QStandardItem(str(serviceLayer["title"]))
         itemLayername.setToolTip(
-            f'{serviceLayer["service_type"].upper()} - {serviceLayer["service_title"]}'
+            f'{stype} - {serviceLayer["service_title"]}'
         )
         # itemFilter is the item used to search filter in. That is why layername is a combi of layername + filter here
         itemFilter = QStandardItem(
@@ -825,7 +828,7 @@ class PdokServicesPlugin(object):
         )
         itemServicetitle = QStandardItem(str(serviceLayer["service_title"]))
         itemServicetitle.setToolTip(
-            f'{serviceLayer["service_type"].upper()} - {serviceLayer["title"]}'
+            f'{stype} - {serviceLayer["title"]}'
         )
         self.sourceModel.appendRow(
             [itemLayername, itemType, itemServicetitle, itemFilter]

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -841,6 +841,33 @@ class PdokServicesPlugin(object):
             )
         return daraa_layers
 
+    def hydroexample_to_json(self):
+        hydroexample_layers = []
+        service_url = "https://test.haleconnect.de/ogcapi/datasets/hydro-example"
+        hydroexample_json = requests.get(service_url).json()
+        service_title = hydroexample_json["title"]
+        service_abstract = hydroexample_json["description"]
+        hydroexample_collections_json = requests.get(service_url + "/collections").json()
+        service_type = "oapif"
+        for collection in hydroexample_collections_json["collections"]:
+            collection_name = collection["id"]
+            collection_title = collection["title"]
+            collection_abstract = collection["description"] if "description" in collection else "Geen abstract gevonden"
+            hydroexample_layers.append(
+                {
+                    "name": collection_name,
+                    "title": collection_title,
+                    "abstract": collection_abstract,
+                    "dataset_md_id": "",
+                    "service_url": service_url,
+                    "service_title": service_title,
+                    "service_abstract": service_abstract,
+                    "service_type": service_type,
+                    "service_md_id": "",
+                }
+            )
+        return hydroexample_layers
+    
     def add_bgttiles_to_layers_pdok(self):
         tiles = []
         service_url = "https://api.pdok.nl/lv/bgt/ogc/v1_0"

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -47,6 +47,7 @@ from qgis.core import (
     QgsMessageLog,
     QgsRasterLayer,
     QgsVectorLayer,
+    QgsVectorTileLayer,
     QgsLayerTreeLayer,
     QgsWkbTypes,
 )
@@ -169,6 +170,8 @@ class PdokServicesPlugin(object):
             "wmts": "bottom",
             "wfs": "top",
             "wcs": "top",
+            "oapif": "top",
+            "oat": "bottom",
         }
 
         self.add_fav_actions_to_toolbar_button()
@@ -357,6 +360,8 @@ class PdokServicesPlugin(object):
             "WMS": "Layer",
             "WMTS": "Layer",
             "WFS": "Featuretype",
+            "OAPIF": "OGC API - Features",
+            "OAT": "OGC API - Tiles",
         }
         layername_key = f"{layername_key_mapping[stype]}"
         if stype == 'OAPIF': # OAPIF Daraa dataset is not in NGR
@@ -411,6 +416,7 @@ class PdokServicesPlugin(object):
         self.dlg.ui.comboSelectProj.clear()
         self.dlg.ui.wmsStyleComboBox.clear()
 
+        # vectortiles??
         show_list = {
             self.dlg.ui.comboSelectProj: ["WMS", "WMTS"],
             self.dlg.ui.labelCrs: ["WMS", "WMTS"],
@@ -563,11 +569,21 @@ class PdokServicesPlugin(object):
             format = "GEOTIFF"
             uri = f"cache=AlwaysNetwork&crs=EPSG:28992&format={format}&identifier={layername}&url={url.split('?')[0]}"
             return QgsRasterLayer(uri, title, "wcs")
+        elif servicetype == "oapif": # OGC API Features
+            uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
+            return QgsVectorLayer(uri, title, servicetype.upper())
+        elif servicetype == "oat": # OGC API Tiles voor BGT
+            url_template = url + "/tiles/NetherlandsRDNewQuad/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
+            style_url = url + "/styles/bgt_standaardvisualisatie"
+            minmaxz_coord = 12
+            type = "xyz"
+            uri = f"styleUrl={style_url}&url={url_template}&type={type}&zmax={minmaxz_coord}&zmin={minmaxz_coord}&http-header:referer="
+            return QgsVectorTileLayer(uri, title)
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'
                 kan niet worden geladen door de plugin of door QGIS.
-                Is het niet beschikbaar als wms, wmts of wfs?
+                Is het niet beschikbaar als wms, wmts, wfs, oapif of oat (vectortile)?
                 """
             )
             return
@@ -763,6 +779,39 @@ class PdokServicesPlugin(object):
         :return:
         """
         return value.lower() == 'true' if isinstance(value, str) else bool(value)
+    def add_bgttiles_to_json(self):
+        tiles = []
+        service_url = "https://api.pdok.nl/lv/bgt/ogc/v1_0"
+        bgttiles_json = requests.get(service_url).json()
+        dataset_title = bgttiles_json["title"]
+        dataset_abstract = bgttiles_json["description"]
+        service_type = "oat"
+        styles = requests.get(service_url + "/styles").json()
+        tiles.append(
+            {
+                "name": dataset_title,
+                "title": dataset_title,
+                "abstract": dataset_abstract,
+                "dataset_md_id": "2cb4769c-b56e-48fa-8685-c48f61b9a319",
+                "styles": [
+                    {
+                        "title": styles['styles'][0]['title'],
+                        "name": styles['styles'][0]['id']
+                    },
+                    {
+                        "title": styles['styles'][1]['title'],
+                        "name": styles['styles'][1]['id']
+                    }
+                ],
+                "service_url": service_url,
+                "service_title":  "BGT OGC API (vector) Tiles",
+                "service_abstract": "BGT Vector Tiles service op basis van OGC API Tiles koppelvlak. De BGT, Basisregistratie Grootschalige Topografie, wordt de gedetailleerde grootschalige basiskaart (digitale kaart) van heel Nederland, waarin op een eenduidige manier de ligging van alle fysieke objecten zoals gebouwen, wegen, water, spoorlijnen en (landbouw)terreinen is geregistreerd.",
+                "service_type": service_type,
+                "service_md_id": "356fc922-f910-4874-b72a-dbb18c1bed3e",
+            }
+        )
+        return tiles
+    
 
     def run(self, hiddenDialog=False):
         """
@@ -777,9 +826,14 @@ class PdokServicesPlugin(object):
         self.clean_ls_search_action.setEnabled(not flashing_geoms)
 
         if self.services_loaded == False:
+            # Init self.layers_pdok with BGT OGC API Tiles manually
+            self.layers_pdok = self.add_bgttiles_to_json()
+
+            self.layers_pdok.extend(self.daraa_to_json())
             pdokjson = os.path.join(self.plugin_dir, "resources", "layers-pdok.json")
             with open(pdokjson, "r", encoding="utf-8") as f:
-                self.layers_pdok = json.load(f)
+                self.layers_pdok.extend(json.load(f))
+
 
             self.sourceModel = QStandardItemModel()
 

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -495,8 +495,7 @@ class PdokServicesPlugin(object):
         match = re.search(pattern, crs_string)
         if match:
             return f"EPSG:{match.group(2)}"
-        else:
-            return crs_string
+        return crs_string
 
     def quote_wmts_url(self, url):
         """

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -480,14 +480,17 @@ class PdokServicesPlugin(object):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
         elif stype == "OGC API - Tiles":
+            tiles = self.current_layer["tiles"][0]
+            crs_list = []
             try:
-                crs = self.current_layer["crs"]
+                crs_list = [tileset["tileset_crs"] for tileset in tiles["tilesets"]]
             except KeyError:
-                crs = "EPSG:28992"
-            crs = crs.split(",")
-            self.dlg.ui.comboSelectProj.addItems(map(self.extract_crs, crs))
-            for i in range(len(crs)):
-                if crs[i] == "EPSG:28992":
+                crs_list = ["EPSG:3857"]
+            self.dlg.ui.comboSelectProj.addItems(map(self.extract_crs, crs_list))
+            print(crs_list)
+            for i in range(len(crs_list)):
+                print(crs_list[i])
+                if crs_list[i].split("/")[-1] == "3857":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
     def extract_crs(self, crs_string):
@@ -608,14 +611,12 @@ class PdokServicesPlugin(object):
             return QgsVectorLayer(uri, title, "OAPIF")
         elif servicetype == "api tiles":  # OGC API Tiles
 
-            # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered elsewhere.
+            # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered incorrectly.
             crs = self.get_crs_comboselect()
-            crs_mapping = {
-                "EPSG:28992": "NetherlandsRDNewQuad",
-                "EPSG:3857": "WebMercatorQuad",
-                "EPSG:4258": "EuropeanETRS89_GRS80Quad_Draft",
-                "EPSG:3035": "EuropeanETRS89_LAEAQuad",
-            }
+            tiles = self.current_layer["tiles"][0]
+            tilesets = tiles["tilesets"]
+            used_tileset = next((tileset for tileset in tilesets if tileset["tileset_crs"].endswith(crs.split(":")[1])), None)
+
             # Style toevoegen in laag vanuit ui
             selected_style_name = (
                 self.current_layer["default"] if "default" in self.current_layer else ""
@@ -627,7 +628,7 @@ class PdokServicesPlugin(object):
                 title += f" [{selected_style_name}]"
 
             url_template = (
-                url + "/tiles/" + crs_mapping[crs] + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
+                url + "/tiles/" + used_tileset["tileset_id"] + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
             )
             if crs == "EPSG:28992":
                 maxz_coord = 12
@@ -635,6 +636,7 @@ class PdokServicesPlugin(object):
                 maxz_coord = 14
             else:
                 maxz_coord = 17
+            # A warning is shown when adding a non-webmercator layer
             if crs != "EPSG:3857":
                 self.show_warning(
                     f"""OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). 

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -635,7 +635,14 @@ class PdokServicesPlugin(object):
                 maxz_coord = 14
             else:
                 maxz_coord = 17
-            minz_coord = 1  
+            if crs != "EPSG:3857":
+                self.show_warning(
+                    f"""OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). 
+                Het gebruik van andere CRS zorgt momenteel voor foutieve projecties.
+                Zie: https://github.com/qgis/QGIS/issues/54673  
+                """
+                )
+            minz_coord = 1
             # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
             type = "xyz"

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -476,9 +476,7 @@ class PdokServicesPlugin(object):
             except KeyError:
                 crs_list = ["EPSG:3857"]
             self.dlg.ui.comboSelectProj.addItems(map(self.extract_crs, crs_list))
-            print(crs_list)
             for i in range(len(crs_list)):
-                print(crs_list[i])
                 if crs_list[i].split("/")[-1] == "3857":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -868,80 +868,48 @@ class PdokServicesPlugin(object):
             )
         return hydroexample_layers
     
-    def add_bgttiles_to_layers_pdok(self):
-        tiles = []
-        service_url = "https://api.pdok.nl/lv/bgt/ogc/v1_0"
-        bgttiles_json = requests.get(service_url).json()
-        dataset_title = bgttiles_json["title"]
-        dataset_abstract = bgttiles_json["description"]
-        service_type = "oat"
-        styles = requests.get(service_url + "/styles").json()
-        service_tiles = requests.get(service_url + "/tiles").json()
-        tiles.append(
-            {
-                "name": dataset_title,
-                "title": dataset_title,
-                "abstract": dataset_abstract,
-                "dataset_md_id": "2cb4769c-b56e-48fa-8685-c48f61b9a319",
-                "styles": [
-                    {
-                        "title": styles["styles"][0]["title"],
-                        "name": styles["styles"][0]["id"],
-                    },
-                    {
-                        "title": styles["styles"][1]["title"],
-                        "name": styles["styles"][1]["id"],
-                    },
-                ],
-                "default": styles["default"],
-                "tilematrixsets": "EPSG:28992",
-                "service_url": service_url,
-                "service_title": service_tiles["title"],
-                "service_abstract": service_tiles["description"],
-                "service_type": service_type,
-                "service_md_id": "356fc922-f910-4874-b72a-dbb18c1bed3e",
-            }
-        )
-        return tiles
-
-    def add_bagtiles_to_layers_pdok(self):
-        tiles = []
-        service_url = "https://api.pdok.nl/lv/bag/ogc/v0_1"
-        bagtiles_json = requests.get(service_url).json()
-        dataset_title = bagtiles_json["title"]
-        dataset_abstract = bagtiles_json["description"]
-        service_type = "oat"
-        styles = requests.get(service_url + "/styles").json()
-        service_tiles = requests.get(service_url + "/tiles").json()
-        tiles.append(
-            {
-                "name": dataset_title,
-                "title": dataset_title,
-                "abstract": dataset_abstract,
-                "dataset_md_id": "aa3b5e6e-7baa-40c0-8972-3353e927ec2f",
-                "styles": [
-                    {
-                        "title": styles["styles"][0]["title"],
-                        "name": styles["styles"][0]["id"],
-                    }
-                ],
-                "default": styles["default"],
-                "tilematrixsets": "EPSG:28992,EPSG:3857,EPSG:4258",
-                "service_url": service_url,
-                "service_title": service_tiles["title"],
-                "service_abstract": service_tiles["description"],
-                "service_type": service_type,
-                "service_md_id": "",
-            }
-        )
-        return tiles
-
-    def extend_layer_pdok_ogcapi(self):
+    def extend_layer_pdok_ogcapi(self, urls_oaf = [], urls_oat = []):
         layers_pdok = []
-        layers_pdok = self.add_bgttiles_to_layers_pdok()
-        layers_pdok.extend(self.add_bagtiles_to_layers_pdok())
-        layers_pdok.extend(self.daraa_to_layers_pdok())
+        layers_pdok = self.retrieve_layers_from_oat_endpoint(urls_oat)
+        layers_pdok.extend(self.retrieve_layers_from_oaf_endpoint(urls_oaf))
         return layers_pdok
+    
+    def retrieve_layers_from_oat_endpoint(self, urls = []):
+        oat_layers = []
+        for url in urls:
+            url_info = requests.get(url).json()
+            dataset_title = url_info.get('title', url.split('/')[-1])
+            # For the two test datasets, we hardcode some information for now which can not yet be retrieved from the endpoint
+            if 'bag' in url:
+                tms = "EPSG:28992,EPSG:3857,EPSG:4258"
+                dataset_md_id = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
+                service_md_id = ""
+            elif 'bgt' in url:
+                tms = "EPSG:28992"
+                dataset_md_id = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
+                service_md_id = "356fc922-f910-4874-b72a-dbb18c1bed3e"
+
+            dataset_abstract = url_info.get('description', "Geen abstract gevonden")
+            service_type = "oat"
+            styles = requests.get(url + "/styles").json()
+            tiles_info = requests.get(url + "/tiles").json()
+            tile_object = {
+                "name": dataset_title,
+                "title": dataset_title,
+                "abstract": dataset_abstract,
+                "dataset_md_id": dataset_md_id,
+                "styles": [{"title": style["title"], "name": style["id"]} for style in styles["styles"]],
+                "default": styles["default"],
+                "tilematrixsets": tms,
+                "service_url": url,
+                "service_title": tiles_info["title"],
+                "service_abstract": tiles_info["description"],
+                "service_type": service_type,
+                "service_md_id": service_md_id,
+            }
+            oat_layers.append(tile_object)
+        return oat_layers
+    
     def retrieve_layers_from_oaf_endpoint(self, urls = []):
         oaf_layers = []
         for url in urls:

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -1207,7 +1207,7 @@ class PdokServicesPlugin(object):
                         **self.current_layer,
                         **{"selectedStyle": selected_style},
                     }
-                add_fav_action = QAction(f"Voeg deze laag toe aan favourieten")
+                add_fav_action = QAction(f"Voeg deze laag toe aan favorieten")
                 add_fav_action.setIcon(self.fav_icon)
                 menu.addAction(add_fav_action)
                 action = menu.exec_(self.dlg.servicesView.mapToGlobal(position))

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -608,7 +608,7 @@ class PdokServicesPlugin(object):
             return QgsVectorLayer(uri, title, "OAPIF")
         elif servicetype == "api tiles":  # OGC API Tiles
 
-            # CRS does not work correctly in qgis/gdal. We can set a crs (non-webmercator), but it is not displayed as expected.
+            # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered elsewhere.
             crs = self.get_crs_comboselect()
             crs_mapping = {
                 "EPSG:28992": "NetherlandsRDNewQuad",
@@ -639,7 +639,7 @@ class PdokServicesPlugin(object):
             # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
             type = "xyz"
-            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&crs={crs}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
+            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
             tile_layer = QgsVectorTileLayer(uri, title)
 
             # Set the VT layer CRS and load the styleUrl

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -418,10 +418,10 @@ class PdokServicesPlugin(object):
 
         # vectortiles??
         show_list = {
-            self.dlg.ui.comboSelectProj: ["WMS", "WMTS"],
-            self.dlg.ui.labelCrs: ["WMS", "WMTS"],
-            self.dlg.ui.wmsStyleComboBox: ["WMS"],
-            self.dlg.ui.wmsStyleLabel: ["WMS"],
+            self.dlg.ui.comboSelectProj: ["WMS", "WMTS", "OAT"],
+            self.dlg.ui.labelCrs: ["WMS", "WMTS", "OAT"],
+            self.dlg.ui.wmsStyleComboBox: ["WMS", "OAT"],
+            self.dlg.ui.wmsStyleLabel: ["WMS", "OAT"],
         }
 
         for ui_el in show_list.keys():
@@ -456,12 +456,31 @@ class PdokServicesPlugin(object):
                 if crs[i] == "EPSG:28992":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
-        if stype == "WMTS":
+        if stype == "WMTS" or stype == "OAT":
             tilematrixsets = self.current_layer["tilematrixsets"].split(",")
             self.dlg.ui.comboSelectProj.addItems(tilematrixsets)
             for i in range(len(tilematrixsets)):
                 if tilematrixsets[i].startswith("EPSG:28992"):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
+
+        if stype == "OAT":
+            styles = self.current_layer["styles"]
+            nr_styles = len(styles)
+            style_str = "styles" if nr_styles > 1 else "style"
+            self.dlg.ui.wmsStyleLabel.setText(
+                f"Style ({nr_styles} {style_str} beschikbaar)"
+            )
+            style_title_names = [
+                x["title"] if "title" in x else x["name"] for x in styles
+            ]
+            self.dlg.ui.wmsStyleComboBox.addItems(style_title_names)
+            self.dlg.ui.wmsStyleComboBox.setCurrentIndex(0)
+            completer = QCompleter(style_title_names, self.dlg.ui.wmsStyleComboBox)
+            completer.setFilterMode(Qt.MatchContains)
+            self.dlg.ui.wmsStyleComboBox.setCompleter(completer)
+            self.dlg.ui.wmsStyleComboBox.setEnabled(
+                nr_styles > 1  # enable if more than one style
+            )
 
     def quote_wmts_url(self, url):
         """
@@ -573,8 +592,25 @@ class PdokServicesPlugin(object):
             uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
             return QgsVectorLayer(uri, title, servicetype.upper())
         elif servicetype == "oat": # OGC API Tiles voor BGT
+
+            # CRS met oat werkt nog niet correct in qgis/gdal
+            if self.dlg.ui.comboSelectProj.currentIndex() == -1:
+                crs = "EPSG:28992"
+            else:
+                crs = self.dlg.ui.comboSelectProj.currentText()
+
+            # Style toevoegen in laag vanuit ui
+            selected_style_name = self.current_layer['default'] if "default" in self.current_layer else ""
+            selected_style = self.get_selected_style()
+            if selected_style is not None:
+                selected_style_name = selected_style["name"]
+                selected_style_title = selected_style["name"]
+                if "title" in selected_style:
+                    selected_style_title = selected_style["title"]
+                title += f" [{selected_style_title}]"
+            
             url_template = url + "/tiles/NetherlandsRDNewQuad/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
-            style_url = url + "/styles/bgt_standaardvisualisatie"
+            style_url = url + "/styles/" + selected_style_name + "?f=json"
             minmaxz_coord = 12
             type = "xyz"
             uri = f"styleUrl={style_url}&url={url_template}&type={type}&zmax={minmaxz_coord}&zmin={minmaxz_coord}&http-header:referer="
@@ -803,6 +839,8 @@ class PdokServicesPlugin(object):
                         "name": styles['styles'][1]['id']
                     }
                 ],
+                "default": styles['default'],
+                "tilematrixsets": "EPSG:28992",
                 "service_url": service_url,
                 "service_title":  "BGT OGC API (vector) Tiles",
                 "service_abstract": "BGT Vector Tiles service op basis van OGC API Tiles koppelvlak. De BGT, Basisregistratie Grootschalige Topografie, wordt de gedetailleerde grootschalige basiskaart (digitale kaart) van heel Nederland, waarin op een eenduidige manier de ligging van alle fysieke objecten zoals gebouwen, wegen, water, spoorlijnen en (landbouw)terreinen is geregistreerd.",

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -635,7 +635,9 @@ class PdokServicesPlugin(object):
                 maxz_coord = 14
             else:
                 maxz_coord = 17
-            minz_coord = 1  # Better performance wise, see QGIS issue https://github.com/qgis/QGIS/issues/54312
+            minz_coord = 1  
+            # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
+            # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
             type = "xyz"
             uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
             return QgsVectorTileLayer(uri, title)

--- a/pdokservicesplugin/processing_provider/processing_ahn.py
+++ b/pdokservicesplugin/processing_provider/processing_ahn.py
@@ -49,9 +49,8 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
 
     wcs_url = "https://service.pdok.nl/rws/ahn/wcs/v1_0"
     cap_url = f"{wcs_url}?request=GetCapabilities&service=WCS"
-    coverages = [ "dtm_05m", "dsm_05m"]
+    coverages = ["dtm_05m", "dsm_05m"]
     default_coverage = coverages[0]
-
 
     def tr(self, string):
         """
@@ -139,7 +138,7 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
             self.OUTPUT = "OUTPUT"  # recommended name for the main output parameter
             self.ATTRIBUTE_NAME = "ATTRIBUTE_NAME"
             self.COVERAGE_ID = "COVERAGE_ID"
-           
+
             self.addParameter(
                 QgsProcessingParameterFeatureSource(
                     self.INPUT,
@@ -191,11 +190,13 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
             # retrieve wcs object
             _xml_bytes = get_request_bytes(PDOKWCSTool.cap_url)
             self.wcs = WebCoverageService_2_0_1(PDOKWCSTool.wcs_url, _xml_bytes, None)
-            
+
             for cov in PDOKWCSTool.coverages:
                 desc_cov_url = f"{PDOKWCSTool.wcs_url}?request=DescribeCoverage&service=WCS&version=2.0.1&coverageId={cov}"
                 desc_cov_resp = get_request_bytes(desc_cov_url)
-                self.wcs._describeCoverage[cov] = etree.fromstring(desc_cov_resp) # _describeCoverage is cache for DescribeCoverage responses => https://github.com/geopython/OWSLib/blob/0eaf201d587e42237415f0010e8940275cd50ba8/owslib/coverage/wcsBase.py#LL53C37-L53C37
+                self.wcs._describeCoverage[cov] = etree.fromstring(
+                    desc_cov_resp
+                )  # _describeCoverage is cache for DescribeCoverage responses => https://github.com/geopython/OWSLib/blob/0eaf201d587e42237415f0010e8940275cd50ba8/owslib/coverage/wcsBase.py#LL53C37-L53C37
                 # so by filling cache, we ensure owslib does not retrieve describecoverage docs, but we do it ourselves
 
             # read out parameters
@@ -243,7 +244,7 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
                     attr = attrs[i]
                     field_name = field_names[i]
                     new_ft.setAttribute(field_name, attr)
-                
+
                 ds = self.get_gdal_ds_from_wcs(x, y, coverage_id, feedback)
 
                 if ds is None:
@@ -260,8 +261,10 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
                     )
                     ahn_val = None
                 else:
-                    ahn_val = round(ahn_val, 2) # reduce precision to 2 digits after the decimal point
-                    
+                    ahn_val = round(
+                        ahn_val, 2
+                    )  # reduce precision to 2 digits after the decimal point
+
                 new_ft.setAttribute(attribute_name, ahn_val)
                 new_ft.setGeometry(geom)
                 sink.addFeature(new_ft, QgsFeatureSink.FastInsert)
@@ -289,11 +292,11 @@ class PDOKWCSTool(QgsProcessingAlgorithm):
             )
             raise QgsProcessingException(message)
 
-
     def get_gdal_ds_from_wcs(self, x, y, coverage_id, feedback):
-        """returns none when x,y outside coverage boundingbox
-        """
-        (minx,miny,maxx,maxy) = self.wcs.contents[coverage_id].boundingboxes[0]['bbox'] # assuming boundingboxes[0] contains nativeproj bounding box
+        """returns none when x,y outside coverage boundingbox"""
+        (minx, miny, maxx, maxy) = self.wcs.contents[coverage_id].boundingboxes[0][
+            "bbox"
+        ]  # assuming boundingboxes[0] contains nativeproj bounding box
         if x < minx or x > maxx or y < miny or y > maxy:
             return None
         origin = [float(i) for i in self.wcs.contents[coverage_id].grid.origin]

--- a/pdokservicesplugin/ui_pdokservicesplugindialog.py
+++ b/pdokservicesplugin/ui_pdokservicesplugindialog.py
@@ -36,6 +36,7 @@ class Ui_PdokServicesPlugin(object):
         self.servicesView.setSizePolicy(sizePolicy)
         self.servicesView.setMinimumSize(QtCore.QSize(0, 0))
         self.servicesView.setObjectName("servicesView")
+        self.servicesView.horizontalHeader().setDefaultSectionSize(150)
         self.gridLayout_2.addWidget(self.servicesView, 1, 0, 1, 4)
         self.layer_info = QtWidgets.QTextBrowser(self.layers_tab)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)

--- a/pdokservicesplugin/ui_pdokservicesplugindialog.ui
+++ b/pdokservicesplugin/ui_pdokservicesplugindialog.ui
@@ -44,6 +44,9 @@
            <height>0</height>
           </size>
          </property>
+         <attribute name="horizontalHeaderDefaultSectionSize">
+                <number>150</number>
+        </attribute>
         </widget>
        </item>
        <item row="2" column="0" colspan="4">

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -40,7 +40,7 @@ if [[ $nr_of_services != "-" ]];then
   nr_svc_flag="-n ${nr_of_services}"
 fi
 
-docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.2" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
+docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.3" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
   if .key == "service_protocol" then 
     .value = (.value | split(":")[1] | ascii_downcase) | .key = "service_type" 
   elif .key == "service_metadata_id" then 

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -39,7 +39,7 @@ if [[ $nr_of_services != "-" ]];then
   nr_svc_flag="-n ${nr_of_services}"
 fi
 
-docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.0" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
+docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.2" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
   if .key == "service_protocol" then 
     .value = (.value | split(":")[1] | ascii_downcase) | .key = "service_type" 
   elif .key == "service_metadata_id" then 

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -10,6 +10,7 @@ output_file_real=$output_dir/$(basename "$output_file")
 output_file_base=$(basename "$output_file_real")
 cat <<EOF > /tmp/sorting-rules.json
 [
+  { "index": 0, "names": ["tiles$"], "types": ["OGC:API tiles"] },
   { "index": 1, "names": ["^actueel_orthohr$"], "types": ["OGC:WMTS"] },
   { "index": 2, "names": ["^actueel_ortho25$"], "types": ["OGC:WMTS"] },
   { "index": 3, "names": ["^actueel_ortho25ir$"], "types": ["OGC:WMTS"] },

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -49,6 +49,8 @@ docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider
     .key = "dataset_md_id" 
   elif .key == "styles" then
     .value = (.value | map(del(.legend_url)))
+  elif .key == "service_url" and (.value | test("/tiles")) then
+      .value = (.value | split("/tiles")[0])
   else 
     (.) 
   end

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -40,7 +40,7 @@ if [[ $nr_of_services != "-" ]];then
   nr_svc_flag="-n ${nr_of_services}"
 fi
 
-docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.3" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
+docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.4" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
   if .key == "service_protocol" then 
     .value = (.value | split(":")[1] | ascii_downcase) | .key = "service_type" 
   elif .key == "service_metadata_id" then 

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -1,14 +1,38 @@
+#!/usr/bin/env python3
+"""Modify layers-pdok.json with OGC:API records
+
+This script allows the user modify the layers-podk.json file which is used in the
+pdokservicesplugin. The records are generated in this script by requesting 
+various API endpoints that are conform the OGC:API standards.
+
+To run this script, one has to provide a single parameter: [ogcapi|original]
+
+`python3 ./scripts/modify-layers-pdok-ogcapi.py ogcapi`: Adds ogcapi test records to 
+layers-pdok.json and creates a copy of the original file
+
+`python3 ./scripts/modify-layers-pdok-ogcapi.py original`: Replaces layers-pdok.json 
+with the copy file (containing the original .json file) and removes the copy.
+"""
+
 import json
 import os
 import shutil
 import requests
 import sys
 
-# python script to modify layers-pdok for the plugin.
-# provide a single parameter to determine behaviour of the script, either:
-# ogcapi `python3 ./scripts/modify-layers-pdok-ogcapi.py ogcapi`: Adds ogcapi test records to layers-pdok.json and creates a copy
-# original `python3 ./scripts/modify-layers-pdok-ogcapi.py original`: Replaces layers-pdok.json with the original copy and removes the copy
-
+URLS_OAF = [
+    "https://demo.ldproxy.net/daraa", 
+    "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
+    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses"
+]
+URLS_OAT = [
+    "https://api.pdok.nl/lv/bag/ogc/v0_1", 
+    "https://api.pdok.nl/lv/bgt/ogc/v1_0"
+]
+BAG_DATASET_MD_ID = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
+BAG_SERVICE_MD_ID = ""
+BGT_DATASET_MD_ID = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
+BGT_SERVICE_MD_ID = "356fc922-f910-4874-b72a-dbb18c1bed3e"
 
 def extend_layer_pdok_ogcapi(urls_oaf = [], urls_oat = []):
         layers_pdok = []
@@ -22,17 +46,16 @@ def retrieve_layers_from_oat_endpoint(urls = []):
         url_info = requests.get(url).json()
         dataset_title = url_info.get('title', url.split('/')[-1])
         tiles_info = requests.get(url + "/tiles").json()
-        # For the two test datasets, we hardcode some information for now which can not yet be retrieved from the endpoint
         if 'bag' in url:
-            dataset_md_id = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
-            service_md_id = ""
+            dataset_md_id = BAG_DATASET_MD_ID
+            service_md_id = BAG_SERVICE_MD_ID
         elif 'bgt' in url:
-            dataset_md_id = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
-            service_md_id = "356fc922-f910-4874-b72a-dbb18c1bed3e"
+            dataset_md_id = BGT_DATASET_MD_ID
+            service_md_id = BGT_SERVICE_MD_ID
 
         crs = ",".join([tileset["crs"] for tileset in tiles_info["tilesets"]])
         dataset_abstract = url_info.get('description', "Geen abstract gevonden")
-        service_type = "api tiles"#"oat"
+        service_type = "api tiles"
         styles = requests.get(url + "/styles").json()
         tile_object = {
             "name": dataset_title,
@@ -56,6 +79,7 @@ def retrieve_layers_from_oat_endpoint(urls = []):
         }
         oat_layers.append(tile_object)
     return oat_layers 
+
 def retrieve_layers_from_oaf_endpoint(urls = []):
     oaf_layers = []
     for url in urls:
@@ -85,7 +109,7 @@ def retrieve_layers_from_oaf_endpoint(urls = []):
         oaf_layers.extend(url_layer)
     return oaf_layers
 
-def original_layers_pdok():
+def original_layers_pdok(layers_location, backup_file_path):
     # Find backup or print if not exists
     if os.path.exists(backup_file_path):
         shutil.copy2(backup_file_path, layers_location)
@@ -95,7 +119,7 @@ def original_layers_pdok():
         print(f"No backup found at '{backup_file_path}': No files replaced")
     return
 
-def add_ogcapi_records():
+def add_ogcapi_records(layers_location, resources_folder, backup_file_path):
     # Checkout if layers-pdok.json exists
     if not os.path.exists(layers_location):
         print(f"There is no layers-pdok.json file in the correct location: {resources_folder}")
@@ -108,9 +132,8 @@ def add_ogcapi_records():
     else :
         print(f"Backup already exists '{backup_file_path}': No copy made")
 
-
     # For testing the plugin with ogcapi features & tiles: extend original layers-pdok.json
-    extra_records_layers_pdok = extend_layer_pdok_ogcapi(urls_oaf = urls_oaf, urls_oat = urls_oat)
+    extra_records_layers_pdok = extend_layer_pdok_ogcapi(urls_oaf = URLS_OAF, urls_oat = URLS_OAT)
 
     # Load existing data from the JSON file (if it exists)
     try:
@@ -123,50 +146,39 @@ def add_ogcapi_records():
 
     if not all_ogcapi_records_exist:
         extra_records_layers_pdok.extend(data)
-        write_to_layers_file(extra_records_layers_pdok)
+        write_to_layers_file(extra_records_layers_pdok, layers_location)
         print("layers-pdok.json updated succesfully")
     else :
-        write_to_layers_file(data)
+        write_to_layers_file(data, layers_location)
         print(f"All ogcapi records already exist in '{layers_location}': Nothing added") 
     return
 
 # Save the updated data back to the JSON file
-def write_to_layers_file(datafile):
+def write_to_layers_file(datafile, layers_location):
     with open(layers_location, 'w') as file:
         json.dump(datafile, file, indent=4)
     return
 
+def main():
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    resources_folder = os.path.join(current_directory, '..', 'pdokservicesplugin', 'resources')
+    backup_file_path =  os.path.join(resources_folder,'layers-pdok-ORIGINAL-COPY.json')
+    layers_location = os.path.join(resources_folder,'layers-pdok.json')
+    allowed_args = ['ogcapi', 'original']
+    # Check for the correct number of command-line arguments
+    if len(sys.argv) != 2:
+        print("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
+        sys.exit(1)
 
-# We add OAF layers to layers_pdok list 
-urls_oaf = [
-    "https://demo.ldproxy.net/daraa", 
-    "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
-    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses"
-]
-urls_oat = [
-    "https://api.pdok.nl/lv/bag/ogc/v0_1", 
-    "https://api.pdok.nl/lv/bgt/ogc/v1_0"
-]
+    if sys.argv[1] not in allowed_args:
+        print(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
+        sys.exit(1)
+    else :
+        mode = sys.argv[1]
+        if mode == 'ogcapi':
+            add_ogcapi_records(layers_location=layers_location, resources_folder=resources_folder, backup_file_path=backup_file_path)
+        else : # mode == 'original'
+            original_layers_pdok(layers_location=layers_location, backup_file_path=backup_file_path)
 
-# Get correct directory of target and this
-current_directory = os.path.dirname(os.path.abspath(__file__))
-resources_folder = os.path.join(current_directory, '..', 'pdokservicesplugin', 'resources')
-backup_file_path =  os.path.join(resources_folder,'layers-pdok-ORIGINAL-COPY.json')
-layers_location = os.path.join(resources_folder,'layers-pdok.json')
-allowed_args = ['ogcapi', 'original']
-# Check for the correct number of command-line arguments
-if len(sys.argv) != 2:
-    print("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
-    sys.exit(1)
-
-if sys.argv[1] not in allowed_args:
-    print(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
-    sys.exit(1)
-else :
-    mode = sys.argv[1]
-    if mode == 'ogcapi':
-        add_ogcapi_records()
-    else : # mode == 'original'
-        original_layers_pdok()
-
-
+if __name__ == "__main__":
+    main()

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
 """Modify/extend layers-pdok.json with OGC:API records for tiles/features from PDOK
 
-This script allows the user modify the layers-podk.json file which is used in the
+This script allows the user modify the layers-pdok.json file which is used in the
 pdokservicesplugin. The records are generated in this script by requesting 
 various API endpoints that are conform the OGC:API standards.
 
 To run this script, one has to provide a single parameter: [ogcapi|original]
 
+Run the following command from the root of the repository:
 `python3 ./scripts/modify-layers-pdok-ogcapi.py ogcapi`: Adds ogcapi test records to 
-layers-pdok.json and creates a copy of the original file
+layers-pdok.json for tiles/features and creates a copy of the original file
 
 `python3 ./scripts/modify-layers-pdok-ogcapi.py original`: Replaces layers-pdok.json 
 with the copy file (containing the original .json file) and removes the copy.
+
+The URL endpoints that are used in this script to add layers are defined in "URLS_OAF"
+and "URLS_OAT". By modifying these constants, other endpoints can be added locally 
+without this service having a record in NGR.  
 """
 
 import json
@@ -19,6 +24,11 @@ import os
 import shutil
 import requests
 import sys
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+log = logging.getLogger(__name__)
 
 URLS_OAF = [
     "https://api.pdok.nl/lv/bgt/ogc/v1_0-preprod"
@@ -53,7 +63,6 @@ def retrieve_layers_from_oat_endpoint(urls=[]):
             dataset_md_id = BGT_DATASET_MD_ID
             service_md_id = BGT_SERVICE_MD_ID
 
-        crs = ",".join([tileset["crs"] for tileset in tiles_info["tilesets"]])
         dataset_abstract = url_info.get("description", "Geen abstract gevonden")
         service_type = "api tiles"
         styles = requests.get(url + "/styles").json()
@@ -144,18 +153,18 @@ def original_layers_pdok(layers_location, backup_file_path):
     if os.path.exists(backup_file_path):
         shutil.copy2(backup_file_path, layers_location)
         os.remove(backup_file_path)
-        print(
+        log.info(
             f"Backup copy '{backup_file_path}'replaces layers-pdok.json and backup file removed"
         )
     else:
-        print(f"No backup found at '{backup_file_path}': No files replaced")
+        log.info(f"No backup found at '{backup_file_path}': No files replaced")
     return
 
 
 def add_ogcapi_records(layers_location, resources_folder, backup_file_path):
     # Checkout if layers-pdok.json exists
     if not os.path.exists(layers_location):
-        print(
+        log.info(
             f"There is no layers-pdok.json file in the correct location: {resources_folder}"
         )
         sys.exit(1)
@@ -163,11 +172,11 @@ def add_ogcapi_records(layers_location, resources_folder, backup_file_path):
     # Create a backup copy of the original file if it doesn't exist
     if not os.path.exists(backup_file_path):
         shutil.copy2(layers_location, backup_file_path)
-        print(
+        log.info(
             f"Backup copy '{backup_file_path}' created with original layers-pdok.json"
         )
     else:
-        print(f"Backup already exists '{backup_file_path}': No copy made")
+        log.info(f"Backup already exists '{backup_file_path}': No copy made")
 
     # For testing the plugin with ogcapi features & tiles: extend original layers-pdok.json
     extra_records_layers_pdok = extend_layer_pdok_ogcapi(
@@ -188,10 +197,10 @@ def add_ogcapi_records(layers_location, resources_folder, backup_file_path):
     if not all_ogcapi_records_exist:
         extra_records_layers_pdok.extend(data)
         write_to_layers_file(extra_records_layers_pdok, layers_location)
-        print("layers-pdok.json updated succesfully")
+        log.info("layers-pdok.json updated succesfully")
     else:
         write_to_layers_file(data, layers_location)
-        print(f"All ogcapi records already exist in '{layers_location}': Nothing added")
+        log.info(f"All ogcapi records already exist in '{layers_location}': Nothing added")
     return
 
 
@@ -211,11 +220,11 @@ def main():
     allowed_args = ["ogcapi", "original"]
     # Check for the correct number of command-line arguments
     if len(sys.argv) != 2:
-        print("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
+        log.info("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
         sys.exit(1)
 
     if sys.argv[1] not in allowed_args:
-        print(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
+        log.info(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
         sys.exit(1)
     else:
         mode = sys.argv[1]

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -1,0 +1,168 @@
+import json
+import os
+import shutil
+import requests
+import sys
+
+# python script to modify layers-pdok for the plugin.
+# provide a single parameter to determine behaviour of the script, either:
+# ogcapi `python3 ./scripts/modify-layers-pdok-ogcapi.py ogcapi`: Adds ogcapi test records to layers-pdok.json and creates a copy
+# original `python3 ./scripts/modify-layers-pdok-ogcapi.py original`: Replaces layers-pdok.json with the original copy and removes the copy
+
+
+def extend_layer_pdok_ogcapi(urls_oaf = [], urls_oat = []):
+        layers_pdok = []
+        layers_pdok = retrieve_layers_from_oat_endpoint(urls_oat)
+        layers_pdok.extend(retrieve_layers_from_oaf_endpoint(urls_oaf))
+        return layers_pdok
+    
+def retrieve_layers_from_oat_endpoint(urls = []):
+    oat_layers = []
+    for url in urls:
+        url_info = requests.get(url).json()
+        dataset_title = url_info.get('title', url.split('/')[-1])
+        # For the two test datasets, we hardcode some information for now which can not yet be retrieved from the endpoint
+        if 'bag' in url:
+            tms = "EPSG:28992,EPSG:3857,EPSG:4258"
+            dataset_md_id = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
+            service_md_id = ""
+        elif 'bgt' in url:
+            tms = "EPSG:28992"
+            dataset_md_id = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
+            service_md_id = "356fc922-f910-4874-b72a-dbb18c1bed3e"
+
+        dataset_abstract = url_info.get('description', "Geen abstract gevonden")
+        service_type = "oat"
+        styles = requests.get(url + "/styles").json()
+        tiles_info = requests.get(url + "/tiles").json()
+        tile_object = {
+            "name": dataset_title,
+            "title": dataset_title,
+            "abstract": dataset_abstract,
+            "dataset_md_id": dataset_md_id,
+            "styles": [{"title": style["title"], "name": style["id"]} for style in styles["styles"]],
+            "default": styles["default"],
+            "tilematrixsets": tms,
+            "service_url": url,
+            "service_title": tiles_info["title"],
+            "service_abstract": tiles_info["description"],
+            "service_type": service_type,
+            "service_md_id": service_md_id,
+        }
+        oat_layers.append(tile_object)
+    return oat_layers
+    
+def retrieve_layers_from_oaf_endpoint(urls = []):
+    oaf_layers = []
+    for url in urls:
+        url_layer = []
+        url_info = requests.get(url).json()
+        service_title = url_info['title'] if 'title' in url_info else url.split('/')[-1]
+        service_abstract = url_info['description'] if 'description' in url_info else  "Geen abstract gevonden"
+        service_type = "oapif"
+        collection_json = requests.get(url + "/collections").json()
+        for collection in collection_json["collections"]:
+            collection_name = collection["id"]
+            collection_title = collection["title"]
+            collection_abstract = collection["description"] if "description" in collection else "Geen abstract gevonden"
+            url_layer.append(
+                {
+                    "name": collection_name,
+                    "title": collection_title,
+                    "abstract": collection_abstract,
+                    "dataset_md_id": "",
+                    "service_url": url,
+                    "service_title": service_title,
+                    "service_abstract": service_abstract,
+                    "service_type": service_type,
+                    "service_md_id": "",
+                }
+            )
+        oaf_layers.extend(url_layer)
+    return oaf_layers
+
+def original_layers_pdok():
+    # Find backup or print if not exists
+    if os.path.exists(backup_file_path):
+        shutil.copy2(backup_file_path, layers_location)
+        os.remove(backup_file_path)
+        print(f"Backup copy '{backup_file_path}'replaces layers-pdok.json and backup file removed")
+    else :
+        print(f"No backup found at '{backup_file_path}': No files replaced")
+    return
+
+def add_ogcapi_records():
+    # Checkout if layers-pdok.json exists
+    if not os.path.exists(layers_location):
+        print(f"There is no layers-pdok.json file in the correct location: {resources_folder}")
+        sys.exit(1)
+
+    # Create a backup copy of the original file if it doesn't exist
+    if not os.path.exists(backup_file_path):
+        shutil.copy2(layers_location, backup_file_path)
+        print(f"Backup copy '{backup_file_path}' created with original layers-pdok.json")
+    else :
+        print(f"Backup already exists '{backup_file_path}': No copy made")
+
+
+    # For testing the plugin with ogcapi features & tiles: extend original layers-pdok.json
+    extra_records_layers_pdok = extend_layer_pdok_ogcapi(urls_oaf = urls_oaf, urls_oat = urls_oat)
+
+    # Load existing data from the JSON file (if it exists)
+    try:
+        with open(layers_location, 'r', encoding="utf-8") as file:
+            data = json.load(file)
+    except FileNotFoundError:
+        data = []
+
+    all_ogcapi_records_exist = all(record in data for record in extra_records_layers_pdok)
+
+    if not all_ogcapi_records_exist:
+        extra_records_layers_pdok.extend(data)
+        write_to_layers_file(extra_records_layers_pdok)
+        print("layers-pdok.json updated succesfully")
+    else :
+        write_to_layers_file(data)
+        print(f"All ogcapi records already exist in '{layers_location}': Nothing added") 
+    return
+
+# Save the updated data back to the JSON file
+def write_to_layers_file(datafile):
+    with open(layers_location, 'w') as file:
+        json.dump(datafile, file, indent=4)
+    return
+
+
+# We add OAF layers to layers_pdok list 
+urls_oaf = [
+    "https://demo.ldproxy.net/daraa", 
+    "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
+    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses"
+]
+urls_oat = [
+    "https://api.pdok.nl/lv/bag/ogc/v0_1", 
+    "https://api.pdok.nl/lv/bgt/ogc/v1_0"
+]
+
+# Get correct directory of target and this
+current_directory = os.path.dirname(os.path.abspath(__file__))
+resources_folder = os.path.join(current_directory, '..', 'pdokservicesplugin', 'resources')
+backup_file_path =  os.path.join(resources_folder,'layers-pdok-ORIGINAL-COPY.json')
+layers_location = os.path.join(resources_folder,'layers-pdok.json')
+allowed_args = ['ogcapi', 'original']
+# Check for the correct number of command-line arguments
+if len(sys.argv) != 2:
+    print("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
+    sys.exit(1)
+
+if sys.argv[1] not in allowed_args:
+    print(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
+    sys.exit(1)
+else :
+    mode = sys.argv[1]
+    if mode == 'ogcapi':
+        add_ogcapi_records()
+    else : # mode == 'original'
+        original_layers_pdok()
+
+

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Modify layers-pdok.json with OGC:API records
+"""Modify/extend layers-pdok.json with OGC:API records for tiles/features from PDOK
 
 This script allows the user modify the layers-podk.json file which is used in the
 pdokservicesplugin. The records are generated in this script by requesting 
@@ -57,6 +57,7 @@ def retrieve_layers_from_oat_endpoint(urls=[]):
         dataset_abstract = url_info.get("description", "Geen abstract gevonden")
         service_type = "api tiles"
         styles = requests.get(url + "/styles").json()
+        tiles = requests.get(url + "/tiles").json()
         tile_object = {
             "name": dataset_title,
             "title": dataset_title,
@@ -64,6 +65,7 @@ def retrieve_layers_from_oat_endpoint(urls=[]):
             "dataset_md_id": dataset_md_id,
             "styles": [
                 {
+                    "id": style["id"],
                     "name": style["title"],
                     "url": next(
                         link["href"]
@@ -73,9 +75,19 @@ def retrieve_layers_from_oat_endpoint(urls=[]):
                 }
                 for style in styles["styles"]
             ],
-            "minscale": "",
-            "maxscale": "",
-            "crs": crs,
+            "tiles": [
+                {
+                    "title": tiles["title"],
+                    "abstract": tiles["description"],
+                    "tilesets": [
+                        {
+                            "tileset_id": tileset["tileMatrixSetId"],
+                            "tileset_crs": tileset["crs"]
+                        }
+                        for tileset in tiles["tilesets"]
+                    ]
+                }
+            ],
             "service_url": url,
             "service_title": tiles_info["title"],
             "service_abstract": tiles_info["description"],

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -97,7 +97,7 @@ def retrieve_layers_from_oaf_endpoint(urls=[]):
         service_abstract = (
             url_info["description"]
             if "description" in url_info
-            else "Geen abstract gevonden"
+            else ""
         )
         service_type = "api features"  # "oapif"
         collection_json = requests.get(url + "/collections").json()
@@ -107,7 +107,7 @@ def retrieve_layers_from_oaf_endpoint(urls=[]):
             collection_abstract = (
                 collection["description"]
                 if "description" in collection
-                else "Geen abstract gevonden"
+                else ""
             )
             url_layer.append(
                 {

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -21,16 +21,14 @@ import requests
 import sys
 
 URLS_OAF = [
-    "https://demo.ldproxy.net/daraa",
-    "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
-    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses",
+    "https://api.pdok.nl/lv/bgt/ogc/v1_0-preprod"
 ]
 URLS_OAT = [
-    "https://api.pdok.nl/lv/bag/ogc/v0_1",
+    "https://api.pdok.nl/lv/bag/ogc/v1_0",
     "https://api.pdok.nl/lv/bgt/ogc/v1_0",
 ]
 BAG_DATASET_MD_ID = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
-BAG_SERVICE_MD_ID = ""
+BAG_SERVICE_MD_ID = "b0f20313-2892-415e-82c1-bf77a984e8d8"
 BGT_DATASET_MD_ID = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
 BGT_SERVICE_MD_ID = "356fc922-f910-4874-b72a-dbb18c1bed3e"
 
@@ -99,6 +97,9 @@ def retrieve_layers_from_oaf_endpoint(urls=[]):
             if "description" in url_info
             else ""
         )
+        if "bgt" in url:
+            dataset_md_id = BGT_DATASET_MD_ID
+            service_md_id = BGT_SERVICE_MD_ID
         service_type = "api features"  # "oapif"
         collection_json = requests.get(url + "/collections").json()
         for collection in collection_json["collections"]:
@@ -114,12 +115,12 @@ def retrieve_layers_from_oaf_endpoint(urls=[]):
                     "name": collection_name,
                     "title": collection_title,
                     "abstract": collection_abstract,
-                    "dataset_md_id": "",
+                    "dataset_md_id": dataset_md_id,
                     "service_url": url,
                     "service_title": service_title,
                     "service_abstract": service_abstract,
                     "service_type": service_type,
-                    "service_md_id": "",
+                    "service_md_id": service_md_id,
                 }
             )
         oaf_layers.extend(url_layer)

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -21,40 +21,42 @@ import requests
 import sys
 
 URLS_OAF = [
-    "https://demo.ldproxy.net/daraa", 
+    "https://demo.ldproxy.net/daraa",
     "https://test.haleconnect.de/ogcapi/datasets/hydro-example",
-    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses"
+    "https://test.haleconnect.de/ogcapi/datasets/simplified-addresses",
 ]
 URLS_OAT = [
-    "https://api.pdok.nl/lv/bag/ogc/v0_1", 
-    "https://api.pdok.nl/lv/bgt/ogc/v1_0"
+    "https://api.pdok.nl/lv/bag/ogc/v0_1",
+    "https://api.pdok.nl/lv/bgt/ogc/v1_0",
 ]
 BAG_DATASET_MD_ID = "aa3b5e6e-7baa-40c0-8972-3353e927ec2f"
 BAG_SERVICE_MD_ID = ""
 BGT_DATASET_MD_ID = "2cb4769c-b56e-48fa-8685-c48f61b9a319"
 BGT_SERVICE_MD_ID = "356fc922-f910-4874-b72a-dbb18c1bed3e"
 
-def extend_layer_pdok_ogcapi(urls_oaf = [], urls_oat = []):
-        layers_pdok = []
-        layers_pdok = retrieve_layers_from_oat_endpoint(urls_oat)
-        layers_pdok.extend(retrieve_layers_from_oaf_endpoint(urls_oaf))
-        return layers_pdok
-    
-def retrieve_layers_from_oat_endpoint(urls = []):
+
+def extend_layer_pdok_ogcapi(urls_oaf=[], urls_oat=[]):
+    layers_pdok = []
+    layers_pdok = retrieve_layers_from_oat_endpoint(urls_oat)
+    layers_pdok.extend(retrieve_layers_from_oaf_endpoint(urls_oaf))
+    return layers_pdok
+
+
+def retrieve_layers_from_oat_endpoint(urls=[]):
     oat_layers = []
     for url in urls:
         url_info = requests.get(url).json()
-        dataset_title = url_info.get('title', url.split('/')[-1])
+        dataset_title = url_info.get("title", url.split("/")[-1])
         tiles_info = requests.get(url + "/tiles").json()
-        if 'bag' in url:
+        if "bag" in url:
             dataset_md_id = BAG_DATASET_MD_ID
             service_md_id = BAG_SERVICE_MD_ID
-        elif 'bgt' in url:
+        elif "bgt" in url:
             dataset_md_id = BGT_DATASET_MD_ID
             service_md_id = BGT_SERVICE_MD_ID
 
         crs = ",".join([tileset["crs"] for tileset in tiles_info["tilesets"]])
-        dataset_abstract = url_info.get('description', "Geen abstract gevonden")
+        dataset_abstract = url_info.get("description", "Geen abstract gevonden")
         service_type = "api tiles"
         styles = requests.get(url + "/styles").json()
         tile_object = {
@@ -64,10 +66,15 @@ def retrieve_layers_from_oat_endpoint(urls = []):
             "dataset_md_id": dataset_md_id,
             "styles": [
                 {
-                "name": style["title"], 
-                "url": next(link["href"] for link in style["links"] if link["rel"] == "stylesheet"),
-                } 
-                for style in styles["styles"]],
+                    "name": style["title"],
+                    "url": next(
+                        link["href"]
+                        for link in style["links"]
+                        if link["rel"] == "stylesheet"
+                    ),
+                }
+                for style in styles["styles"]
+            ],
             "minscale": "",
             "maxscale": "",
             "crs": crs,
@@ -78,21 +85,30 @@ def retrieve_layers_from_oat_endpoint(urls = []):
             "service_md_id": service_md_id,
         }
         oat_layers.append(tile_object)
-    return oat_layers 
+    return oat_layers
 
-def retrieve_layers_from_oaf_endpoint(urls = []):
+
+def retrieve_layers_from_oaf_endpoint(urls=[]):
     oaf_layers = []
     for url in urls:
         url_layer = []
         url_info = requests.get(url).json()
-        service_title = url_info['title'] if 'title' in url_info else url.split('/')[-1]
-        service_abstract = url_info['description'] if 'description' in url_info else  "Geen abstract gevonden"
-        service_type = 'api features'#"oapif"
+        service_title = url_info["title"] if "title" in url_info else url.split("/")[-1]
+        service_abstract = (
+            url_info["description"]
+            if "description" in url_info
+            else "Geen abstract gevonden"
+        )
+        service_type = "api features"  # "oapif"
         collection_json = requests.get(url + "/collections").json()
         for collection in collection_json["collections"]:
             collection_name = collection["id"]
             collection_title = collection["title"]
-            collection_abstract = collection["description"] if "description" in collection else "Geen abstract gevonden"
+            collection_abstract = (
+                collection["description"]
+                if "description" in collection
+                else "Geen abstract gevonden"
+            )
             url_layer.append(
                 {
                     "name": collection_name,
@@ -109,62 +125,77 @@ def retrieve_layers_from_oaf_endpoint(urls = []):
         oaf_layers.extend(url_layer)
     return oaf_layers
 
+
 def original_layers_pdok(layers_location, backup_file_path):
     # Find backup or print if not exists
     if os.path.exists(backup_file_path):
         shutil.copy2(backup_file_path, layers_location)
         os.remove(backup_file_path)
-        print(f"Backup copy '{backup_file_path}'replaces layers-pdok.json and backup file removed")
-    else :
+        print(
+            f"Backup copy '{backup_file_path}'replaces layers-pdok.json and backup file removed"
+        )
+    else:
         print(f"No backup found at '{backup_file_path}': No files replaced")
     return
+
 
 def add_ogcapi_records(layers_location, resources_folder, backup_file_path):
     # Checkout if layers-pdok.json exists
     if not os.path.exists(layers_location):
-        print(f"There is no layers-pdok.json file in the correct location: {resources_folder}")
+        print(
+            f"There is no layers-pdok.json file in the correct location: {resources_folder}"
+        )
         sys.exit(1)
 
     # Create a backup copy of the original file if it doesn't exist
     if not os.path.exists(backup_file_path):
         shutil.copy2(layers_location, backup_file_path)
-        print(f"Backup copy '{backup_file_path}' created with original layers-pdok.json")
-    else :
+        print(
+            f"Backup copy '{backup_file_path}' created with original layers-pdok.json"
+        )
+    else:
         print(f"Backup already exists '{backup_file_path}': No copy made")
 
     # For testing the plugin with ogcapi features & tiles: extend original layers-pdok.json
-    extra_records_layers_pdok = extend_layer_pdok_ogcapi(urls_oaf = URLS_OAF, urls_oat = URLS_OAT)
+    extra_records_layers_pdok = extend_layer_pdok_ogcapi(
+        urls_oaf=URLS_OAF, urls_oat=URLS_OAT
+    )
 
     # Load existing data from the JSON file (if it exists)
     try:
-        with open(layers_location, 'r', encoding="utf-8") as file:
+        with open(layers_location, "r", encoding="utf-8") as file:
             data = json.load(file)
     except FileNotFoundError:
         data = []
 
-    all_ogcapi_records_exist = all(record in data for record in extra_records_layers_pdok)
+    all_ogcapi_records_exist = all(
+        record in data for record in extra_records_layers_pdok
+    )
 
     if not all_ogcapi_records_exist:
         extra_records_layers_pdok.extend(data)
         write_to_layers_file(extra_records_layers_pdok, layers_location)
         print("layers-pdok.json updated succesfully")
-    else :
+    else:
         write_to_layers_file(data, layers_location)
-        print(f"All ogcapi records already exist in '{layers_location}': Nothing added") 
+        print(f"All ogcapi records already exist in '{layers_location}': Nothing added")
     return
 
-# Save the updated data back to the JSON file
+
 def write_to_layers_file(datafile, layers_location):
-    with open(layers_location, 'w') as file:
+    with open(layers_location, "w") as file:
         json.dump(datafile, file, indent=4)
     return
 
+
 def main():
     current_directory = os.path.dirname(os.path.abspath(__file__))
-    resources_folder = os.path.join(current_directory, '..', 'pdokservicesplugin', 'resources')
-    backup_file_path =  os.path.join(resources_folder,'layers-pdok-ORIGINAL-COPY.json')
-    layers_location = os.path.join(resources_folder,'layers-pdok.json')
-    allowed_args = ['ogcapi', 'original']
+    resources_folder = os.path.join(
+        current_directory, "..", "pdokservicesplugin", "resources"
+    )
+    backup_file_path = os.path.join(resources_folder, "layers-pdok-ORIGINAL-COPY.json")
+    layers_location = os.path.join(resources_folder, "layers-pdok.json")
+    allowed_args = ["ogcapi", "original"]
     # Check for the correct number of command-line arguments
     if len(sys.argv) != 2:
         print("Usage: modify-layers-pdok-ogcapi.py [ogcapi|original]")
@@ -173,12 +204,19 @@ def main():
     if sys.argv[1] not in allowed_args:
         print(f"Arg {sys.argv[1]} not allowed, only [ogcapi|original] allowed")
         sys.exit(1)
-    else :
+    else:
         mode = sys.argv[1]
-        if mode == 'ogcapi':
-            add_ogcapi_records(layers_location=layers_location, resources_folder=resources_folder, backup_file_path=backup_file_path)
-        else : # mode == 'original'
-            original_layers_pdok(layers_location=layers_location, backup_file_path=backup_file_path)
+        if mode == "ogcapi":
+            add_ogcapi_records(
+                layers_location=layers_location,
+                resources_folder=resources_folder,
+                backup_file_path=backup_file_path,
+            )
+        else:  # mode == 'original'
+            original_layers_pdok(
+                layers_location=layers_location, backup_file_path=backup_file_path
+            )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/modify-layers-pdok-ogcapi.py
+++ b/scripts/modify-layers-pdok-ogcapi.py
@@ -32,7 +32,7 @@ def retrieve_layers_from_oat_endpoint(urls = []):
             service_md_id = "356fc922-f910-4874-b72a-dbb18c1bed3e"
 
         dataset_abstract = url_info.get('description', "Geen abstract gevonden")
-        service_type = "oat"
+        service_type = "api tiles"#"oat"
         styles = requests.get(url + "/styles").json()
         tiles_info = requests.get(url + "/tiles").json()
         tile_object = {
@@ -59,7 +59,7 @@ def retrieve_layers_from_oaf_endpoint(urls = []):
         url_info = requests.get(url).json()
         service_title = url_info['title'] if 'title' in url_info else url.split('/')[-1]
         service_abstract = url_info['description'] if 'description' in url_info else  "Geen abstract gevonden"
-        service_type = "oapif"
+        service_type = 'api features'#"oapif"
         collection_json = requests.get(url + "/collections").json()
         for collection in collection_json["collections"]:
             collection_name = collection["id"]


### PR DESCRIPTION
Functionality is added to support OGC:API tiles & features services:

- Updating the ngr-services-spider to 0.6.4 to allow retrieving PDOK ogcapi tiles services
- Retrieve ogcapi tiles/features services using script
- Add ogcapi features layers from the plugin
- Add vector tile layers with comboSelect for styles and crs (only webmercator is currently supported in QGIS, remaining crs are displayed but greyed out)
- Minor UI update (slightly increase column width)
-  Add test script to extend pdok-layers.json with custom (ogcapi tiles) url endpoints, can be used for testing and mocking ngr records for 'new' services
- Update documentation
- Update layers-pdok.json to include ogcapi tiles for BAG & BGT

NB: NGR does not yet contain services using the ogcapi features protocol. The NGR-spider also does not correctly support retrieving this, but a PR for this functionality is created. The PDOK backlog contains a ticket to update the ngr-spider and plugin (bump the version in the script in the plugin) to retrieve the correct services as soon as ogcapi features is in production. 
